### PR TITLE
Don't filter notifications by type

### DIFF
--- a/tooi/api/timeline.py
+++ b/tooi/api/timeline.py
@@ -191,9 +191,6 @@ class NotificationTimeline(Timeline):
     https://docs.joinmastodon.org/methods/notifications/
     """
 
-    # TODO: not included: follow_request, poll, update, admin.sign_up, admin.report
-    TYPES = ["mention", "follow", "favourite", "reblog"]
-
     def __init__(self, instance: InstanceInfo):
         super().__init__("Notifications", instance)
         self._most_recent_id = None
@@ -215,7 +212,6 @@ class NotificationTimeline(Timeline):
 
     async def notification_generator(
             self,
-            path: str,
             params: Params = None,
             limit: int | None = None) -> EventGenerator:
 
@@ -230,13 +226,12 @@ class NotificationTimeline(Timeline):
             yield events
 
     def fetch(self, limit: int | None = None):
-        return self.notification_generator({"types[]": self.TYPES}, limit)
+        return self.notification_generator(limit=limit)
 
     async def update(self, limit: int | None = None) -> EventGenerator:
         eventslist = fetch_timeline(
                 self.instance,
                 "/api/v1/notifications",
-                params={"types[]": self.TYPES},
                 limit=limit,
                 since_id=self._most_recent_id)
 

--- a/tooi/widgets/event_detail.py
+++ b/tooi/widgets/event_detail.py
@@ -68,9 +68,9 @@ class UnknownEventDetail(Static, can_focus=True):
     }
     """
 
-    def __init__(self, event):
+    def __init__(self, event: NotificationEvent):
         self.event = event
-        super().__init__("<unknown event>")
+        super().__init__(f"<unknown notification type: {event.notification.type}>")
 
 
 class EventDetailPlaceholder(Static, can_focus=True):


### PR DESCRIPTION
By showing all notifications, even if we don't know how to properly display them, we'll make it more obvious what we still need to implement.

BTW, filtering was already not working because the invocation of notification_generator passed Params as the first parameter instead of second. I removed the path parameter from that function since it's not used.